### PR TITLE
Remove COMPOSER_HOME env var

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -56,8 +56,6 @@ services:
           target: php
           secrets:
               - kernel-secret
-        environment:
-          COMPOSER_HOME: /var/www/html
         env_file:
             -   .env
         secrets:


### PR DESCRIPTION
Remove COMPOSER_HOME env var from docker-compose which overrides its default location, making auth.json not be properly read